### PR TITLE
fixing typos in README files 

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -10,7 +10,7 @@ Create a Fission .NET environment with the default .NET runtime image (this does
 fission env create --name dotnet --image fission/dotnet-env
 ```
 
-Use the `hello.cs` to create a Fission Python function:
+Use the `hello.cs` to create a Fission .Net function:
 
 ```
 fission function create --name hello-dotnet --env dotnet --code hello.cs 

--- a/go/README.md
+++ b/go/README.md
@@ -10,7 +10,7 @@ Create a Fission Go environment with the default Go runtime image (this does not
 fission environment create --name go --image fission/go-env-1.16 --builder fission/go-builder-1.16
 ```
 
-Use the `hello.go` to create a Fission Python function:
+Use the `hello.go` to create a Fission Go function:
 
 ```
 fission fn create --name helloworld --env go --src hello.go --entrypoint Handler

--- a/go/README.md
+++ b/go/README.md
@@ -21,7 +21,7 @@ Test the function:
 fission fn test --name helloworld
 ```
 
-To setup a Fo environment on Fission and to learn more about it, check out [Go Environment in Fission](https://github.com/fission/environments/tree/master/go)
+To setup a Go environment on Fission and to learn more about it, check out [Go Environment in Fission](https://github.com/fission/environments/tree/master/go)
 
 Find all Go related code here. Currently, we have the following examples:
 

--- a/go/examples.json
+++ b/go/examples.json
@@ -10,7 +10,7 @@
       "name": "Using Go Modules",
       "description": "How to use Go Modules in Fission",
       "path": "https://github.com/fission/examples/tree/main/go/module-example",
-      "yag": ["Go"],
+      "tag": ["Go"],
       "language": "Go"
     }
 ]

--- a/java/README.md
+++ b/java/README.md
@@ -4,7 +4,7 @@ This is the repository for all Java sample codes for Fission.
 
 ## Getting Started
 
-Create a Fission Go environment with the default Go runtime image (this does not include the build environment):
+Create a Fission Java environment with the default Java runtime image (this does not include the build environment):
 
 ```bash
 fission environment create --name java --image fission/jvm-env --builder fission/jvm-builder
@@ -16,7 +16,7 @@ Create a package
 fission package create --env java --src java-src-pkg.zip
 ```
 
-Use the `HelloWorld.java` to create a Fission Python function:
+Use the `HelloWorld.java` to create a Fission Java function:
 
 ```bash
 fission fn create --name javatest --pkg  java-src-pkg-zip-dqo5 --env java --entrypoint io.fission.HelloWorld


### PR DESCRIPTION
There's been some incorrect instructions (generally typos) in the markdown files. 