### PR TITLE
Fix Java example mistakenly describes Java environment and runtime as Go

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -4,7 +4,7 @@ This is the repository for all Java sample codes for Fission.
 
 ## Getting Started
 
-Create a Fission Go environment with the default Go runtime image (this does not include the build environment):
+Create a Fission Java environment with the default JVM runtime image (this does not include the build environment):
 
 ```bash
 fission environment create --name java --image fission/jvm-env --builder fission/jvm-builder


### PR DESCRIPTION
In the readme file corresponding to the Java example, the Java environment and runtime image are incorrectly described as being for Go. For example:
Create a Fission Go environment with the default Go runtime image (this does not include the build environment): fission environment create --name java --image fission/jvm-env --builder fission/jvm-builder

Fixes: #89