### PR TITLE
Add async-invocation and statestore-eventing examples

### DIFF
--- a/miscellaneous/README.md
+++ b/miscellaneous/README.md
@@ -4,6 +4,7 @@ This is the repository for all Fission sample codes. These are not specific to a
 
 We have the following examples:
 
+- Asynchronous Invocation - *async invocation with retries, a dead-letter queue, and result destinations*
 - Binary Functions
 - Container Functions
 - Dashboards
@@ -16,6 +17,7 @@ We have the following examples:
 - NextJS Prefix Path
 - NodeJS Running Chrome Headless in Fission
 - Specification Examples
+- Statestore Eventing - *built-in pub/sub topics with `fission topic`, no external broker*
 - Tensorflow Serving
 - Websocket
 - Workshops - *example codes showcased during workshops*

--- a/miscellaneous/async-invocation/README.md
+++ b/miscellaneous/async-invocation/README.md
@@ -1,0 +1,181 @@
+# Asynchronous Invocation
+
+A webhook processor that books orders in the background, with retries, a dead-letter queue, and result destinations.
+
+A normal Fission invocation is synchronous.
+The caller holds the connection open until the function returns.
+An asynchronous invocation is different.
+The router accepts the request, enqueues it on the statestore queue, and returns a durable invocation id right away.
+A background dispatcher delivers the request later.
+It retries a failing delivery with backoff, dead-letters the delivery if it cannot succeed, and can invoke another function with the result.
+
+This example is one business process — a webhook that books an order — and it shows every part of the feature:
+
+| Feature | Where shown |
+|---|---|
+| Async invocation through an HTTP trigger | `--invocation-mode async` on the trigger, so a third-party webhook sender gets async delivery without setting a header |
+| Retries with a per-function attempt budget | `--async-retry-max-attempts` on a function whose first version has a bug |
+| Dead-letter queue | The buggy delivery exhausts its retries and lands in the DLQ |
+| Result destinations | `--async-on-success` / `--async-on-failure` invoke a logging function with the delivery result |
+| DLQ inspection and redrive | `dlq list`, `dlq show`, fix the bug, `dlq redrive` |
+
+## Prerequisites
+
+Asynchronous invocation is off by default.
+It needs the statestore for its durable queue:
+
+```bash
+helm upgrade --install fission fission-charts/fission-all \
+  --namespace fission \
+  --set statestore.enabled=true \
+  --set statestore.mode=embedded \
+  --set asyncInvocation.enabled=true
+```
+
+Embedded statestore mode is enough for this example.
+
+A Node.js environment for the example functions:
+
+```bash
+fission environment create --name nodejs --image ghcr.io/fission/node-env-22
+```
+
+## The 10-minute tour
+
+### 1. Create the destination functions
+
+These are the functions the async dispatcher invokes with the result of a delivery — one for a success, one for a dead-letter.
+
+```bash
+fission function create --name order-booked --env nodejs --code functions/on-success.js
+fission function create --name order-alert --env nodejs --code functions/on-failure.js
+```
+
+### 2. Create the webhook processor (buggy v1) and wire it for async delivery
+
+`functions/process-order-webhook.js` books an order, but it has a bug: it assumes `amount` always arrives as a number.
+A legacy sender in this scenario sends it as a quoted string, and the function throws.
+
+```bash
+fission function create --name process-order-webhook --env nodejs \
+  --code functions/process-order-webhook.js \
+  --async-retry-max-attempts 2 \
+  --async-max-age 5m \
+  --async-on-success order-booked \
+  --async-on-failure order-alert
+```
+
+`--async-retry-max-attempts` caps out at 3 — the platform's shared queue enforces that ceiling on every function, so a request for more than 3 is rejected.
+
+### 3. Create an HTTP trigger that forces async mode
+
+A webhook sender from a third party cannot set the `X-Fission-Invoke-Mode: async` header, so the trigger sets it for them:
+
+```bash
+fission httptrigger create --name webhook --method POST --url /webhook \
+  --function process-order-webhook --invocation-mode async
+```
+
+### 4. Send a well-formed webhook
+
+```bash
+curl -s -D - -o /dev/null -X POST http://$FISSION_ROUTER/webhook \
+  -H "Content-Type: application/json" \
+  -d @payloads/order-ok.json
+```
+
+```
+HTTP/1.1 202 Accepted
+X-Fission-Invocation-Id: asyncinv/1f9c2a7e4b3d4f0a9c8e6d5f7a8b9c0d
+Content-Type: application/json
+```
+
+The router accepted the request and returned a durable invocation id.
+It never waited for the function to run.
+Check the function's own log, then the success destination's log:
+
+```bash
+fission function log --name process-order-webhook
+# booked order ord-1001 for 4999 cents
+
+fission function log --name order-booked
+# order booked: invocation=asyncinv/1f9c2a7e4b3d4f0a9c8e6d5f7a8b9c0d attempts=1 response={"orderId":"ord-1001","cents":4999}
+```
+
+### 5. Send a webhook that triggers the bug
+
+```bash
+curl -s -D - -o /dev/null -X POST http://$FISSION_ROUTER/webhook \
+  -H "Content-Type: application/json" \
+  -d @payloads/order-bad-amount.json
+```
+
+The router still returns `202 Accepted` with an invocation id — acceptance and delivery are separate steps.
+`order.amount` is a quoted string in this payload, so the function throws and returns a 500.
+A 500 is a retryable failure, so the dispatcher retries it with backoff until the 2-attempt budget is spent, then dead-letters it:
+
+```bash
+fission function log --name order-alert
+# ALERT: order booking dead-lettered: invocation=asyncinv/... condition=RetriesExhausted attempts=2 response=internal error booking order: order.amount.toFixed is not a function
+```
+
+### 6. Inspect the dead-letter queue
+
+```bash
+fission function dlq list
+```
+
+```
+ID                                          NAMESPACE   FUNCTION                REASON              ATTEMPTS   DIED
+asyncinv/7c3d9e1a2b4f5061829a3b4c5d6e7f80   default     process-order-webhook   retries exhausted   2          9s
+```
+
+```bash
+fission function dlq show --id asyncinv/7c3d9e1a2b4f5061829a3b4c5d6e7f80
+```
+
+The full envelope includes the original request body, the response status and body from the last attempt, and the attempt count — everything needed to diagnose the failure without reproducing it by hand.
+
+### 7. Fix the bug and redeploy
+
+`functions/process-order-webhook-fixed.js` coerces `amount` with `Number()` instead of assuming it is already a number:
+
+```bash
+fission function update --name process-order-webhook \
+  --code functions/process-order-webhook-fixed.js
+```
+
+### 8. Redrive the dead-lettered invocation
+
+```bash
+fission function dlq redrive --id asyncinv/7c3d9e1a2b4f5061829a3b4c5d6e7f80
+```
+
+```
+redrove 1 dead-lettered invocation(s)
+```
+
+Redrive re-enqueues the **original** request — the same webhook body that failed before — for one more delivery attempt against the now-fixed function:
+
+```bash
+fission function log --name process-order-webhook
+# booked order ord-1002 for 4999 cents
+
+fission function log --name order-booked
+# order booked: invocation=asyncinv/7c3d9e1a2b4f5061829a3b4c5d6e7f80 attempts=1 response={"orderId":"ord-1002","cents":4999}
+```
+
+The same payload that used to crash now books cleanly, because it goes through the fixed code, not the old one.
+
+## Concepts you'll see
+
+- **`--invocation-mode async`** on a trigger — every request through it is async, with no header from the caller.
+  Direct callers that *can* set headers use `fission function test --name <fn> --async` instead.
+- **Retry budget** — `--async-retry-max-attempts` bounds delivery attempts before a 5xx/timeout failure is dead-lettered.
+  It is clamped to 3, the platform's shared queue ceiling.
+- **Max age** — `--async-max-age` bounds how long an invocation may wait for a successful delivery, independent of the attempt count.
+- **4xx is never retried** — a function that rejects a payload with a 4xx (as the fixed version does for a missing `orderId`) is dead-lettered immediately, with reason `http_4xx`, instead of burning the retry budget on something a retry can never fix.
+- **Destinations** — `--async-on-success` / `--async-on-failure` invoke another function with a result envelope (invocation id, condition, attempt count, request and response payloads) after a delivery settles.
+  `--async-on-success-topic` / `--async-on-failure-topic` publish that same envelope to a topic instead, for more than one subscriber.
+- **DLQ redrive** — resets the attempt count and re-enqueues the original request; it does not change the function's code, so a redrive only succeeds once the underlying bug is fixed.
+- **`dlq redrive --all`** re-enqueues every dead-lettered invocation, and **`dlq purge`** discards them all — both take a `--queue` flag to target a broker egress DLQ instead of the async invocation queue, and `dlq purge` does not take `--all` (it always purges the whole queue).

--- a/miscellaneous/async-invocation/functions/on-failure.js
+++ b/miscellaneous/async-invocation/functions/on-failure.js
@@ -1,0 +1,15 @@
+// The --async-on-failure destination. The async dispatcher POSTs the same
+// result envelope shape here when an invocation is dead-lettered (retries
+// exhausted, max age, or a permanent 4xx) -- stand-in for paging on-call;
+// a real deployment would call PagerDuty, Slack, or similar.
+module.exports = async function (context) {
+    const result = context.request.body || {};
+    const decode = (b64) => (b64 ? Buffer.from(b64, 'base64').toString('utf8') : '');
+
+    console.error(
+        `ALERT: order booking dead-lettered: invocation=${result.requestContext?.invocationId} ` +
+            `condition=${result.requestContext?.condition} attempts=${result.requestContext?.attempts} ` +
+            `response=${decode(result.responsePayload)}`
+    );
+    return { status: 200, body: 'alerted' };
+};

--- a/miscellaneous/async-invocation/functions/on-success.js
+++ b/miscellaneous/async-invocation/functions/on-success.js
@@ -1,0 +1,14 @@
+// The --async-on-success destination. The async dispatcher POSTs the
+// Lambda-shaped result envelope here after a successful delivery
+// (Content-Type: application/json, so `context.request.body` is already the
+// parsed envelope). requestPayload/responsePayload ride the wire as base64.
+module.exports = async function (context) {
+    const result = context.request.body || {};
+    const decode = (b64) => (b64 ? Buffer.from(b64, 'base64').toString('utf8') : '');
+
+    console.log(
+        `order booked: invocation=${result.requestContext?.invocationId} ` +
+            `attempts=${result.requestContext?.attempts} response=${decode(result.responsePayload)}`
+    );
+    return { status: 200, body: 'ok' };
+};

--- a/miscellaneous/async-invocation/functions/process-order-webhook-fixed.js
+++ b/miscellaneous/async-invocation/functions/process-order-webhook-fixed.js
@@ -1,0 +1,39 @@
+// v2: the fix.
+//
+// `Number(order.amount)` coerces a quoted amount ("49.99") the same as a
+// numeric one, so the redelivered payload that used to crash now books
+// cleanly. A structurally invalid payload (no orderId) is now a proper 4xx
+// instead of an uncaught exception: the async dispatcher never retries a
+// 4xx, so it dead-letters immediately (reason `http_4xx`) instead of
+// spending the retry budget on something retrying can never fix.
+module.exports = async function (context) {
+    const order = context.request.body || {};
+
+    if (!order.orderId || !order.customerEmail) {
+        return {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                errorType: 'InvalidOrder',
+                cause: { orderId: order.orderId, customerEmail: order.customerEmail },
+            }),
+        };
+    }
+
+    const amount = Number(order.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+        return {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ errorType: 'InvalidOrder', cause: { amount: order.amount } }),
+        };
+    }
+
+    const cents = Math.round(amount * 100);
+    console.log(`booked order ${order.orderId} for ${cents} cents`);
+    return {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderId: order.orderId, cents }),
+    };
+};

--- a/miscellaneous/async-invocation/functions/process-order-webhook.js
+++ b/miscellaneous/async-invocation/functions/process-order-webhook.js
@@ -1,0 +1,22 @@
+// v1: books an order from a webhook payload.
+//
+// BUG: this version assumes `amount` always arrives as a number. A legacy
+// sender in this scenario sends it as a quoted string ("49.99") instead, and
+// `order.amount.toFixed()` throws on a string. The catch below turns that
+// into a 500 -- a failure the async dispatcher treats as retryable, since it
+// looks exactly like a downstream call that timed out.
+module.exports = async function (context) {
+    const order = context.request.body || {};
+    try {
+        const cents = Math.round(order.amount.toFixed(2) * 100);
+        console.log(`booked order ${order.orderId} for ${cents} cents`);
+        return {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ orderId: order.orderId, cents }),
+        };
+    } catch (err) {
+        console.error(`failed to book order ${order.orderId}: ${err.message}`);
+        return { status: 500, body: `internal error booking order: ${err.message}` };
+    }
+};

--- a/miscellaneous/async-invocation/payloads/order-bad-amount.json
+++ b/miscellaneous/async-invocation/payloads/order-bad-amount.json
@@ -1,0 +1,5 @@
+{
+    "orderId": "ord-1002",
+    "customerEmail": "buyer@example.com",
+    "amount": "49.99"
+}

--- a/miscellaneous/async-invocation/payloads/order-ok.json
+++ b/miscellaneous/async-invocation/payloads/order-ok.json
@@ -1,0 +1,5 @@
+{
+    "orderId": "ord-1001",
+    "customerEmail": "buyer@example.com",
+    "amount": 49.99
+}

--- a/miscellaneous/eventing-topics/README.md
+++ b/miscellaneous/eventing-topics/README.md
@@ -1,0 +1,196 @@
+# Statestore eventing — order events fan-out
+
+RFC-0027 statestore-backed eventing.
+A `messageQueueType: statestore` trigger reads a durable topic on the Fission statestore.
+No external broker is present.
+No Kafka, no NATS, no RabbitMQ.
+
+The scenario is an order-events fan-out.
+A producer function creates an order.
+Two consumer functions subscribe to the same `orders` topic through separate `MessageQueueTrigger` objects.
+One consumer updates inventory.
+The other consumer sends a customer notification.
+Each consumer owns its own durable cursor over the topic.
+A failure in one consumer does not block the other.
+
+| Feature | Where it shows up |
+| --- | --- |
+| `messageQueueType: statestore` MQ trigger, zero external broker | `orders-to-inventory`, `orders-to-notify` |
+| A function publishing to a topic, via an async-invocation destination (`--async-on-success-topic`) | `create-order` |
+| `fission topic publish` — manual event injection | Injecting the poison event |
+| `fission topic peek` — inspect a topic's tail | Every step below |
+| `ResponseTopic` | `orders-to-notify` publishes its confirmation to `notifications-sent` |
+| `ErrorTopic` + poison isolation (RFC-0027 invariant E5) | `orders-to-inventory` publishes an exhausted event to `orders-errors` |
+| Per-trigger durable cursor, independent fan-out | The inventory failure does not block the notification consumer |
+
+## Prerequisites
+
+Statestore eventing needs the statestore, async invocation, and (by default) the eventing consumer head:
+
+```bash
+helm upgrade --install fission fission-charts/fission-all --namespace fission \
+  --set statestore.enabled=true \
+  --set statestore.mode=embedded \
+  --set asyncInvocation.enabled=true
+```
+
+- `statestore.enabled` turns on the durable store that backs every RFC-0027 topic.
+- `asyncInvocation.enabled` is required for two separate reasons, not one: it lets `create-order` be invoked asynchronously (destinations only fire on async delivery), and it also wires the router's topic admin API — `fission topic publish` and `fission topic peek` return `501 Not Implemented` without it, even though the mqtrigger consumer side is unaffected.
+- `eventing.enabled` defaults to `true` whenever `statestore.enabled` is `true`.
+It deploys the `mqtrigger-statestore` head, the process that actually reads topics and delivers events to `orders-to-inventory` and `orders-to-notify`.
+You do not need to set it explicitly.
+
+A Node.js environment for the example functions:
+
+```bash
+fission environment create --name nodejs --image ghcr.io/fission/node-env-22
+```
+
+## Deploy
+
+```bash
+fission function create --name create-order --env nodejs --code functions/create-order.js \
+  --async-on-success-topic orders
+
+fission function create --name update-inventory --env nodejs --code functions/update-inventory.js
+fission function create --name notify-customer --env nodejs --code functions/notify-customer.js
+
+# --mqtkind fission is required. The CLI's --mqtkind default is "keda", and
+# statestore is a classic-head ("fission" kind) provider — "keda" is rejected.
+# --pollinginterval overrides the CLI's own 30s default with a snappier value
+# for this demo (the provider's own idle-poll default is 1s).
+fission mqtrigger create --name orders-to-inventory \
+  --function update-inventory \
+  --mqtype statestore --mqtkind fission \
+  --topic orders --errortopic orders-errors \
+  --maxretries 2 --pollinginterval 2
+
+fission mqtrigger create --name orders-to-notify \
+  --function notify-customer \
+  --mqtype statestore --mqtkind fission \
+  --topic orders --resptopic notifications-sent \
+  --maxretries 2 --pollinginterval 2
+```
+
+Each `mqtrigger create` prints:
+
+```
+trigger 'orders-to-inventory' created
+```
+
+`fission mqtrigger create` returning does not mean the subscription loop is running yet.
+The `mqtrigger-statestore` head still has to reconcile the new trigger.
+A new subscription starts reading at the topic's current head, so an event published before the subscription is live is never delivered to it.
+Confirm both subscriptions are up before publishing anything:
+
+```bash
+kubectl -n fission logs deploy/mqtrigger-statestore -f | grep "topic subscription started"
+# ... msg="topic subscription started" ... stream=topic/default/orders ...   (once per trigger)
+```
+
+Wait for two lines, one per trigger, then move on.
+
+## Run: publish through the pipeline
+
+### 1. Invoke the producer asynchronously
+
+A synchronous call to `create-order` returns the order and publishes nothing.
+Only an asynchronous call fires the `--async-on-success-topic` destination:
+
+```bash
+fission fn test --name create-order --method POST \
+  --body "$(cat events/order-placed.json)" --async
+```
+
+```
+Accepted (202)
+invocationId: inv-xxxxxxxx
+```
+
+The dispatcher delivers `create-order`, wraps its response in a result envelope, and publishes that envelope to the `orders` topic.
+Give the two subscriptions a moment (up to `--pollinginterval`) to pick it up, then peek both destinations:
+
+```bash
+fission topic peek --topic orders --limit 5
+fission topic peek --topic notifications-sent --limit 5
+```
+
+```
+head: 1
+SEQ  TYPE              AGE  PAYLOAD
+1    application/json  3s   {"version":"1.0","requestContext":{...
+```
+
+The payload on `orders` is the full result envelope, not the raw order.
+This is why `update-inventory.js` and `notify-customer.js` unwrap it: they base64-decode `responsePayload` to get the order JSON `create-order` returned.
+
+### 2. Publish an event by hand
+
+`fission topic publish` is a dev convenience: it appends directly to the topic, bypassing `create-order` entirely.
+Use it to test the consumers without invoking the producer, or to backfill an event:
+
+```bash
+fission topic publish --topic orders \
+  --data "$(cat events/order-placed.json)" --content-type application/json
+```
+
+```
+published to topic "orders" in namespace "default" (statestore)
+```
+
+A directly published event is raw JSON, not a result envelope — `unwrapOrder()` in the consumer functions passes it through unchanged because it has no `requestContext`/`responseContext`.
+
+### 3. Poison event, retries, and the error topic
+
+`events/unknown-sku.json` references a SKU that is not in `update-inventory.js`'s catalog.
+Publish it directly:
+
+```bash
+fission topic publish --topic orders \
+  --data "$(cat events/unknown-sku.json)" --content-type application/json
+```
+
+`orders-to-notify` has no catalog to check.
+It succeeds and publishes a confirmation to `notifications-sent`, same as any other event.
+
+`orders-to-inventory` returns `500` on every attempt — there is no per-attempt state on the mqtrigger delivery path, so retrying cannot change the outcome.
+The subscription retries up to `--maxretries` (3 attempts total, spaced a fixed ~500ms apart — not exponential, not configurable per trigger), then publishes the *original* event, unmodified, to `orders-errors` and advances its cursor.
+This is poison isolation: one bad event cannot wedge the topic for other events or other consumers.
+
+```bash
+fission topic peek --topic orders-errors --limit 5
+```
+
+```
+head: 1
+SEQ  TYPE              AGE  PAYLOAD
+1    application/json  2s   {"orderId":"ord-9999","customer":{"email":"ghost@example.com"}...
+```
+
+Compare that against `notifications-sent`, which now has one more entry than before — the poison order's confirmation went through even though inventory rejected it.
+
+## Concepts you'll see here
+
+- **`messageQueueType: statestore`** — an `MqtKind: fission` (classic-head) provider.
+It needs no broker connection config: it reuses whatever statestore the cluster already has.
+- **Success is any 2xx.**
+  A `201` or `204` from a consumer counts as delivered, same as `200`.
+- **`ErrorTopic` carries the original event**, byte-for-byte, with its original content type — not an error report, not a stack trace.
+- **`ResponseTopic` carries the consumer's response body**, with the response's own `Content-Type` header.
+- **At-least-once, no attempt header.**
+  Unlike an async-invocation destination chain, a statestore mqtrigger delivery carries no attempt-number header.
+Write consumers that are safe to run twice.
+- **Independent cursors, shared stream.**
+  `orders-to-inventory` and `orders-to-notify` each track their own position on the same `orders` stream.
+One falling behind, or exhausting retries on a poison event, does not slow or block the other.
+- **A background reaper trims each subscribed topic to its slowest consumer's cursor.**
+  Two backstops can trim past a stalled consumer's cursor anyway: a 7-day age limit and a 100,000-event size limit, both fixed in this version.
+A subscriber that hits either backstop sees a logged gap, not a hang.
+`orders-errors` and `notifications-sent` have no `MessageQueueTrigger` subscribed to them in this example, so the reaper does not trim them at all — only topics with at least one registered subscriber are reaped.
+
+## What to look at
+
+- **`functions/create-order.js`** — the producer.
+Nothing in it is topic-aware; the publish happens entirely through the function's `--async-on-success-topic` destination config.
+- **`functions/update-inventory.js`** — the permanent-failure path: an unknown SKU fails identically on every attempt, so retries exist only to absorb *transient* failures, not this class of bug.
+- **`functions/notify-customer.js`** — the `ResponseTopic` path, and proof that one trigger's failure is invisible to a sibling trigger on the same topic.

--- a/miscellaneous/eventing-topics/events/order-placed.json
+++ b/miscellaneous/eventing-topics/events/order-placed.json
@@ -1,0 +1,9 @@
+{
+  "orderId": "ord-1001",
+  "customer": { "email": "ana@example.com" },
+  "items": [
+    { "sku": "WIDGET-1", "qty": 2, "unitPrice": 9.99 },
+    { "sku": "GIZMO-2", "qty": 1, "unitPrice": 24.5 }
+  ],
+  "total": 44.48
+}

--- a/miscellaneous/eventing-topics/events/unknown-sku.json
+++ b/miscellaneous/eventing-topics/events/unknown-sku.json
@@ -1,0 +1,8 @@
+{
+  "orderId": "ord-9999",
+  "customer": { "email": "ghost@example.com" },
+  "items": [
+    { "sku": "GHOST-001", "qty": 1, "unitPrice": 5 }
+  ],
+  "total": 5
+}

--- a/miscellaneous/eventing-topics/functions/create-order.js
+++ b/miscellaneous/eventing-topics/functions/create-order.js
@@ -1,0 +1,38 @@
+// Producer. Validates a new order and returns the order event as its
+// response body.
+//
+// Invoke this function ASYNCHRONOUSLY (X-Fission-Invoke-Mode: async, or
+// `fission fn test --async`). Only an async delivery fires the
+// --async-on-success-topic destination that publishes this response to the
+// "orders" topic (RFC-0027). A plain synchronous call returns the same body
+// to the caller, but nothing gets published.
+module.exports = async function (context) {
+    const order = context.request.body || {};
+    const problems = [];
+
+    if (!order.orderId) problems.push('orderId is required');
+    if (!order.customer || !order.customer.email) problems.push('customer.email is required');
+    if (!Array.isArray(order.items) || order.items.length === 0) problems.push('items must be a non-empty array');
+    for (const item of order.items || []) {
+        if (!item.sku || !Number.isInteger(item.qty) || item.qty < 1) {
+            problems.push(`item ${JSON.stringify(item)} needs a sku and a positive integer qty`);
+        }
+    }
+
+    if (problems.length > 0) {
+        return {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ error: 'invalid order', problems }),
+        };
+    }
+
+    const total = order.items.reduce((sum, i) => sum + (i.unitPrice || 0) * i.qty, 0);
+    const event = { ...order, total, placedAt: new Date().toISOString() };
+
+    return {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(event),
+    };
+};

--- a/miscellaneous/eventing-topics/functions/notify-customer.js
+++ b/miscellaneous/eventing-topics/functions/notify-customer.js
@@ -1,0 +1,32 @@
+// Consumer 2, mqtrigger "orders-to-notify". Sends a simulated order
+// confirmation.
+//
+// This trigger's ResponseTopic ("notifications-sent") publishes this
+// function's response on every success. This is a SEPARATE, independent
+// cursor from update-inventory's — each MessageQueueTrigger owns its own
+// durable cursor over the same "orders" stream, so a poison event that
+// exhausts update-inventory's retries never blocks this consumer.
+function unwrapOrder(body) {
+    if (body && typeof body === 'object' && body.requestContext && body.responseContext) {
+        const json = Buffer.from(body.responsePayload || '', 'base64').toString('utf8');
+        return JSON.parse(json);
+    }
+    return body;
+}
+
+module.exports = async function (context) {
+    const order = unwrapOrder(context.request.body) || {};
+    const confirmation = {
+        orderId: order.orderId,
+        email: order.customer?.email,
+        message: `Your order ${order.orderId} for $${order.total} is confirmed.`,
+        sentAt: new Date().toISOString(),
+    };
+
+    console.log('notification sent:', JSON.stringify(confirmation));
+    return {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(confirmation),
+    };
+};

--- a/miscellaneous/eventing-topics/functions/update-inventory.js
+++ b/miscellaneous/eventing-topics/functions/update-inventory.js
@@ -1,0 +1,53 @@
+// Consumer 1, mqtrigger "orders-to-inventory". Decrements stock for each
+// line item on an order event.
+//
+// An unknown SKU is a permanent inventory-service error (500). The
+// statestore mqtrigger delivery path has no typed-error distinction and no
+// attempt-number header, so every attempt fails identically. --maxretries
+// exhausts and the event is routed to the ErrorTopic (RFC-0027 poison
+// isolation, invariant E5) instead of stalling the topic.
+//
+// CATALOG resets on every cold start. This is a demo, not a real inventory
+// store.
+const CATALOG = { 'WIDGET-1': 50, 'GIZMO-2': 30, 'GADGET-3': 12 };
+
+// unwrapOrder handles both shapes an event on this topic can arrive in:
+//
+//  - published by the create-order destination: an RFC-0024 result envelope
+//    ({requestContext, responseContext, responsePayload: base64(body)}).
+//  - published directly with `fission topic publish`: the raw order JSON.
+//
+// requestContext/responseContext only exist on the envelope shape (unlike
+// responsePayload, which is omitted when the producer's response body is
+// empty), so they are the reliable discriminator.
+function unwrapOrder(body) {
+    if (body && typeof body === 'object' && body.requestContext && body.responseContext) {
+        const json = Buffer.from(body.responsePayload || '', 'base64').toString('utf8');
+        return JSON.parse(json);
+    }
+    return body;
+}
+
+module.exports = async function (context) {
+    const order = unwrapOrder(context.request.body) || {};
+    const updates = [];
+
+    for (const item of order.items || []) {
+        if (!(item.sku in CATALOG)) {
+            return {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ error: `unknown sku ${item.sku}` }),
+            };
+        }
+        CATALOG[item.sku] -= item.qty;
+        updates.push({ sku: item.sku, remaining: CATALOG[item.sku] });
+    }
+
+    console.log(`inventory updated for order ${order.orderId}:`, JSON.stringify(updates));
+    return {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderId: order.orderId, updates }),
+    };
+};

--- a/miscellaneous/examples.json
+++ b/miscellaneous/examples.json
@@ -117,5 +117,19 @@
       "path": "https://github.com/fission/examples/tree/main/miscellaneous/workflows/payment-dunning",
       "tag": ["Workflows","Orchestration","Javascript"],
       "language": "Javascript"
+    },
+    {
+      "name": "Asynchronous Invocation: Webhook Order Booking",
+      "description": "Async invocation through an HTTP trigger, with retries, onSuccess/onFailure destinations, and dead-letter-queue inspect/redrive.",
+      "path": "https://github.com/fission/examples/tree/main/miscellaneous/async-invocation",
+      "tag": ["Async","Retries","Dead-letter Queue","Javascript"],
+      "language": "Javascript"
+    },
+    {
+      "name": "Statestore Eventing: Order Events Fan-out",
+      "description": "Built-in messageQueueType: statestore topics with zero external broker; fission topic publish/peek, ResponseTopic/ErrorTopic, and per-trigger cursor fan-out.",
+      "path": "https://github.com/fission/examples/tree/main/miscellaneous/eventing-topics",
+      "tag": ["Eventing","Statestore","Messaging","Javascript"],
+      "language": "Javascript"
     }
 ]


### PR DESCRIPTION
Two runnable examples for the Fission durable/async feature wave, in the style of the merged workflows examples (#94) and stateful examples (#95):

## `miscellaneous/async-invocation/`
Webhook order booking with asynchronous invocation (RFC-0024 surface):
- `--invocation-mode async` on the HTTP trigger, so webhook senders get async delivery with no header
- retries with a per-function attempt budget (`--async-retry-max-attempts`, capped at 3)
- a buggy v1 that exhausts retries and lands in the DLQ; `dlq list/show`, fix, `dlq redrive`
- `--async-on-success` / `--async-on-failure` result destinations

## `miscellaneous/eventing-topics/`
Order events fan-out on built-in statestore topics (RFC-0027 surface), no external broker:
- producer publishes via an async destination topic; two consumers subscribe through `mqtrigger create --mqtype statestore --mqtkind fission`
- `fission topic publish` for manual injection, `fission topic peek` for inspection
- `ErrorTopic` poison isolation and `ResponseTopic` confirmation flow
- independent per-trigger cursors: one consumer's failure does not block the other

Every command and flag was verified against fission source (CLI flag definitions, chart values, statestore subscription/dispatcher semantics). Expected-output blocks are derived from the printed format strings in source; the walkthroughs were not run against a live cluster.

Both examples are registered in `miscellaneous/README.md` and `miscellaneous/examples.json`.

Pairs with the docs on fission/fission.io#314 (which links these paths — merge this before or with that PR so the links resolve).